### PR TITLE
[IMP] Historico de precios en product_autoload #72

### DIFF
--- a/product_autoload/__openerp__.py
+++ b/product_autoload/__openerp__.py
@@ -29,7 +29,8 @@
         'stock',
         'sale',
         'purchase',
-        'product_multi_barcode'
+        'product_multi_barcode',
+        'price_security'
     ],
 
     'data': [
@@ -42,7 +43,7 @@
     'test': [
     ],
     'demo': [
-
+        'data/demo_data.xml'
     ],
     'installable': True,
     'application': False,

--- a/product_autoload/data/demo_data.xml
+++ b/product_autoload/data/demo_data.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <!-- agregar vendor bulonfer -->
+        <record id="partner_bulonfer" model="res.partner">
+            <field name="name">Bulonfer</field>
+            <field name="ref">BULONFER</field>
+            <field name="supplier" eval="1"/>
+        </record>
+
+        <!-- Agregar IVA -->
+        <record id="account_tax_iva_ventas" model="account.tax">
+            <field name="name">IVA Ventas 15.5%</field>
+            <field name="amount">15.5</field>
+            <field name="type_tax_use">sale</field>
+<!--
+            <field name="tax_group_id" eval="9"/>
+            -->
+        </record>
+
+        <record id="account_tax_iva_compras" model="account.tax">
+            <field name="name">IVA Compras 15.5%</field>
+            <field name="amount">15.5</field>
+            <field name="type_tax_use">purchase</field>
+        </record>
+
+        <record id="account_tax_iva_ventas" model="account.tax">
+            <field name="name">IVA Ventas 21%</field>
+            <field name="amount">21</field>
+            <field name="type_tax_use">sale</field>
+        </record>
+
+        <record id="account_tax_iva_compras" model="account.tax">
+            <field name="name">IVA Compras 21%</field>
+            <field name="amount">21</field>
+            <field name="type_tax_use">purchase</field>
+        </record>
+
+    </data>
+</openerp>

--- a/product_autoload/i18n/es_AR.po
+++ b/product_autoload/i18n/es_AR.po
@@ -4,21 +4,16 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c-20180313\n"
+"Project-Id-Version: Odoo Server 9.0c-20180504\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-05-08 22:21+0000\n"
-"PO-Revision-Date: 2018-05-08 22:21+0000\n"
+"POT-Creation-Date: 2018-06-30 21:23+0000\n"
+"PO-Revision-Date: 2018-06-30 21:23+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
-
-#. module: product_autoload
-#: model:ir.model.fields,help:product_autoload.field_account_invoice_line_invoice_discount
-msgid "A discount made with a negative invoice line wich afects all lines in the invoice."
-msgstr "A discount made with a negative invoice line wich afects all lines in the invoice."
 
 #. module: product_autoload
 #: model:ir.model.fields,help:product_autoload.field_product_template_upv
@@ -58,9 +53,24 @@ msgid "Bulk retail quantity of units"
 msgstr "Cantidad de unidades en compra minorista"
 
 #. module: product_autoload
+#: model:ir.model.fields,help:product_autoload.field_product_template_bulonfer_cost
+msgid "Bulonfer Cost price from last replication"
+msgstr "Ultimo Costo Bulonfer"
+
+#. module: product_autoload
+#: model:ir.model.fields,field_description:product_autoload.field_product_template_bulonfer_cost
+msgid "Bulonfer cost"
+msgstr "Bulonfer cost"
+
+#. module: product_autoload
 #: model:ir.ui.view,arch_db:product_autoload.view_custom_config_settings
 msgid "Cancel"
 msgstr "Cancelar"
+
+#. module: product_autoload
+#: model:ir.ui.view,arch_db:product_autoload.product_autoload_tree_view
+msgid "Cash"
+msgstr "Caja"
 
 #. module: product_autoload
 #: model:ir.model.fields,help:product_autoload.field_product_template_invalidate_category
@@ -84,6 +94,11 @@ msgstr "Codigo de bulonfer, no se muestra"
 #: model:ir.ui.view,arch_db:product_autoload.view_custom_config_settings
 msgid "Configure Accounting"
 msgstr "Configurar Contabilidad"
+
+#. module: product_autoload
+#: model:ir.model.fields,help:product_autoload.field_product_template_oldest_cost
+msgid "Cost price from oldest product in stock"
+msgstr "Costo del producto mas viejo en stock"
 
 #. module: product_autoload
 #: model:ir.model.fields,field_description:product_autoload.field_product_autoload_item_create_uid
@@ -112,14 +127,9 @@ msgid "Date and time of last replication"
 msgstr "Fecha hora de la ultima replicacion"
 
 #. module: product_autoload
-#: model:ir.model.fields,field_description:product_autoload.field_product_template_difference
-msgid "Difference"
-msgstr "Dif %"
-
-#. module: product_autoload
-#: model:ir.model.fields,help:product_autoload.field_product_template_difference
-msgid "Difference % in cost price between invoce and system, calculated as (invoice_price-system_price)/invoice_pricethis diference is an error and must go towars zero."
-msgstr "Diferencia % en el precio de costo entre las facturas de compra y el sistema (bulonfer), calculado como (preciofactura-preciosistema)/preciofactura esta diferencia es un error y debe tender a cero."
+#: model:ir.ui.view,arch_db:product_autoload.product_template_tree_view1
+msgid "Dif%"
+msgstr "Dif%"
 
 #. module: product_autoload
 #: model:ir.model.fields,field_description:product_autoload.field_account_invoice_discount_processed
@@ -188,9 +198,9 @@ msgid "Invoice"
 msgstr "Factura"
 
 #. module: product_autoload
-#: model:ir.model.fields,field_description:product_autoload.field_account_invoice_line_invoice_discount
-msgid "Invoice Discount"
-msgstr "Descuenta en factura"
+#: model:ir.ui.view,arch_db:product_autoload.product_template_tree_view1
+msgid "Invoice Cost"
+msgstr "Invoice Cost"
 
 #. module: product_autoload
 #: model:ir.model,name:product_autoload.model_account_invoice_line
@@ -247,6 +257,11 @@ msgid "Margin"
 msgstr "Margen"
 
 #. module: product_autoload
+#: model:ir.ui.view,arch_db:product_autoload.product_template_tree_view1
+msgid "Margin%"
+msgstr "Margen%"
+
+#. module: product_autoload
 #: model:ir.model.fields,field_description:product_autoload.field_product_autoload_item_name
 #: model:ir.model.fields,field_description:product_autoload.field_product_autoload_manager_name
 msgid "Name"
@@ -258,9 +273,26 @@ msgid "No Categorizado"
 msgstr "No Categorizado"
 
 #. module: product_autoload
+#: model:ir.model.fields,field_description:product_autoload.field_product_template_oldest_cost
+msgid "Oldest cost"
+msgstr "Costo mas viejo"
+
+#. module: product_autoload
 #: model:ir.model.fields,field_description:product_autoload.field_product_autoload_item_origin
 msgid "Origin"
 msgstr "Origen"
+
+#. module: product_autoload
+#: model:ir.model.fields,field_description:product_autoload.field_product_autoload_manager_processed
+msgid "Processed products"
+msgstr "Productos procesados"
+
+#. module: product_autoload
+#: model:ir.actions.act_window,name:product_autoload.action_product_autoload
+#: model:ir.ui.menu,name:product_autoload.menu_product_autoload
+#: model:ir.ui.view,arch_db:product_autoload.product_autoload_form_view
+msgid "Product Autoload"
+msgstr "Carga automatica de productos"
 
 #. module: product_autoload
 #: model:ir.model,name:product_autoload.model_product_template
@@ -316,6 +348,11 @@ msgstr "El codigo de barras debe ser unico !"
 #: sql_constraint:product_autoload.item:0
 msgid "The item code must be unique !"
 msgstr "El codigo de item debe ser unico !"
+
+#. module: product_autoload
+#: model:ir.ui.view,arch_db:product_autoload.product_template_tree_view1
+msgid "Today Cost"
+msgstr "Costo hoy"
 
 #. module: product_autoload
 #: model:ir.model.fields,field_description:product_autoload.field_product_template_upv

--- a/product_autoload/models/autoload.py
+++ b/product_autoload/models/autoload.py
@@ -77,7 +77,7 @@ class AutoloadMgr(models.Model):
 
     def load_item(self, data_path, item=ITEM):
         """ Carga los datos en un modelo, chequeando por modificaciones
-            Si cambio el precio recalcula todos precios de los productos
+            Si cambio el margen recalcula todos precios de los productos
         """
         prod_obj = self.env['product.template']
         item_obj = self.env['product_autoload.item']
@@ -117,8 +117,6 @@ class AutoloadMgr(models.Model):
                     prod = prod_obj.search(domain)
                     if prod:
                         prod.recalculate_list_price(item.margin)
-                        _logger.info('recalculate for create {}'
-                                     ''.format(item.code))
 
     def load_productcode(self, data_path):
         """ Borra la tabla productcode y la vuelve a crear con los datos nuevos
@@ -130,9 +128,9 @@ class AutoloadMgr(models.Model):
             reader = csv.reader(file_csv)
             for line in reader:
                 count += 1
-                if count == 2000:
+                if count == 4000:
                     count = 0
-                    _logger.info('REPLICATION: loading +2000 barcodes')
+                    _logger.info('REPLICATION: loading +4000 barcodes')
                 values = {
                     'barcode': line[PC_BARCODE].strip(),
                     'product_code': line[PC_PRODUCT_CODE].strip(),
@@ -140,7 +138,6 @@ class AutoloadMgr(models.Model):
                 }
                 item_obj.create(values)
 
-    @api.multi
     def load_product(self, data_path):
         """ Carga todos los productos teniendo en cuenta la fecha
         """
@@ -221,7 +218,6 @@ class AutoloadMgr(models.Model):
         _logger.info('update categories')
         categ_obj = self.env['product.category']
         item_obj = self.env['product_autoload.item']
-
         prods = self.env['product.template'].search(
             [('invalidate_category', '=', True)], limit=400)
         for prod in prods:
@@ -259,8 +255,9 @@ class AutoloadMgr(models.Model):
             if not categ_id:
                 categ_id = categ_obj.create({'name': item.name,
                                              'parent_id': sec_fam_id.id})
-            _logger.info('Setting {} --> {}'.format(
-                prod.default_code, categ_id.complete_name))
+
+            _logger.info('Setting %s --> %s' %
+                         (prod.default_code, categ_id.complete_name))
             prod.write(
                 {
                     'categ_id': categ_id.id,

--- a/product_autoload/tests/test_autoload.py
+++ b/product_autoload/tests/test_autoload.py
@@ -5,7 +5,8 @@
 from __future__ import division
 
 from openerp.tests.common import TransactionCase
-from ..models.mappers import ProductMapper
+from ..models.mappers import ProductMapper, MAP_NAME, MAP_UPV, \
+    MAP_STANDARD_PRICE, MAP_WEIGHT
 
 #    Forma de correr el test
 #    -----------------------
@@ -23,7 +24,7 @@ from ..models.mappers import ProductMapper
 #
 #   Correr el test con:
 #
-#   oe -Q product_autoload -c bulonfer -d bulonfer_test
+#   oe -Q product_autoload -c iomaq -d iomaq_test
 #
 #
 
@@ -52,122 +53,109 @@ class TestBusiness(TransactionCase):
 
         self.env['res.partner'].create({'name': 'Bulonfer'})
 
+        # definimos una linea del archivo para probar
+        self.line = [
+            '123456',  # Código del producto
+            'nombre-producto',  # Nombre del producto
+            'Descripción del producto',  # Descripción del producto
+            '500.22',  # Precio de costo
+            '100',  # UPV Agrupacion mayorista
+            '200.50',  # Peso bruto en kg
+            '125.85',  # Volumen m3
+            '100',  # Bulto Mayorista
+            '5',  # Bulto Minorista
+            '102.7811.jpg',  # Nombre de la imagen
+            '60',  # Garantia (meses)
+            '15.5',  # IVA %
+            '133',  # idRubro
+            '2018-25-01 13:10:55']  # Timestamp actualización
+
+        self.manager_obj = self.env['product_autoload.manager']
+        self.prod_obj = self.env['product.template']
+
     def test_01_product_mapper(self):
         """ Chequear creacion de ProductMapper ------------------------------01
         """
 
-        line = [
-            '123456',
-            'nombre-producto',
-            'Descripción del producto',
-            '500.22',
-            '100',
-            '200.50',
-            '125.85',
-            '100',
-            '5',
-            '102.7811.jpg',
-            '60',
-            '15.5',
-            '133',
-            '2018-25-01 13:10:55']
-
-        prod = ProductMapper(line, self._data_path, self._vendor,
-                             self._supinfo)
-        self.assertEqual(prod.default_code, '123456')
-        self.assertEqual(prod.name, 'nombre-producto')
-        self.assertEqual(prod.description_sale, 'Descripción del producto')
-        self.assertEqual(prod.standard_price, 500.22)
-        self.assertEqual(prod.upv, 100)
-        self.assertEqual(prod.weight, 200.50)
-        self.assertEqual(prod.volume, 125.85)
-        self.assertEqual(prod.wholesaler_bulk, 100)
-        self.assertEqual(prod.retail_bulk, 5)
-        self.assertEqual(prod.warranty, 60)
-        self.assertEqual(prod.iva, 15.5)
-        self.assertEqual(prod.item_code, '133')
-        self.assertEqual(prod.write_date, '2018-25-01 13:10:55')
-
+        # creamos un dict con los valores pasados por el prod
         val = {
-            'wholesaler_bulk': 100,
-            'retail_bulk': 5,
-            'warranty': 60.0,
-            'upv': 100,
-            'name': 'nombre-producto',
-            'weight': 200.5,
-            'standard_price': 5.0022,
-            'volume': 125.85,
-            'default_code': '123456',
-            'write_date': '2018-25-01 13:10:55',
-            'description_sale': 'Descripci\xc3\xb3n del producto'}
+            'default_code': self.line[0],
+            'name': self.line[1],
+            'description_sale': self.line[2],
+            'bulonfer_cost': float(self.line[3]) / float(self.line[4]),
+            'upv': float(self.line[4]),
+            'weight': float(self.line[5]),
+            'volume': float(self.line[6]),
+            'wholesaler_bulk': float(self.line[7]),
+            'retail_bulk': float(self.line[8]),
+            '_image_name': self.line[9],
+            'warranty': float(self.line[10]),
+            'iva': float(self.line[11]),
+            'item_code': self.line[12],
+            'write_date': self.line[13]
+        }
 
-        val.update(prod.default_values())
+        # cargamos la linea en el mapper
+        prod = ProductMapper(self.line, self._data_path, self._vendor,
+                             self._supinfo)
 
+        # chequeamos que cada propiedad este correcta
+        self.assertEqual(prod.default_code, val['default_code'])
+        self.assertEqual(prod.name, val['name'])
+        self.assertEqual(prod.description_sale, val['description_sale'])
+        self.assertEqual(prod.bulonfer_cost, val['bulonfer_cost'])
+        self.assertEqual(prod.upv, val['upv'])
+        self.assertEqual(prod.weight, val['weight'])
+        self.assertEqual(prod.volume, val['volume'])
+        self.assertEqual(prod.wholesaler_bulk, val['wholesaler_bulk'])
+        self.assertEqual(prod.retail_bulk, val['retail_bulk'])
+        self.assertEqual(prod.warranty, val['warranty'])
+        self.assertEqual(prod.iva, val['iva'])
+        self.assertEqual(prod.item_code, val['item_code'])
+        self.assertEqual(prod.write_date, val['write_date'])
+
+        # verificamos que los datos sean correctos
+        val = prod.values()
         for item in val:
-            self.assertEqual(prod.values(create=True)[item], val[item])
+            self.assertEqual(prod.values()[item], val[item])
+
+        # verificar ademas los default values
+        self.assertEqual(val['type'], 'product')
+        self.assertEqual(val['invoice_policy'], 'order')
+        self.assertEqual(val['purchase_method'], 'purchase')
+
+    def test_02_(self):
+        """ string no unicode -----------------------------------------------02
+        """
+        line = self.line
+        line[MAP_NAME] = b'\x00\xFF\x00\xFF'  # string no utf-8
+        with self.assertRaises(Exception):
+            prod = ProductMapper(line, self._data_path, self._vendor,
+                                 self._supinfo)
 
     def test_03_(self):
-        """ Chequear tipos de campo -----------------------------------------03
+        """ numero es un string ---------------------------------------------03
         """
-        line = [
-            u'1aa\xe11',
-            'nombre-producto',
-            'Descripción del producto',
-            '7750082001169,7750082001169',
-            '1000.52',
-            '501',
-            '200.50',
-            '125.85',
-            '601.AA.3157.jpg',
-            '60',
-            '21',
-            '001',
-            '2018-25-01 13:10:55']
-
+        line = self.line
+        line[MAP_UPV] = 'HHH'  # debe ser numero y es string
         with self.assertRaises(Exception):
             prod = ProductMapper(line, self._data_path, self._vendor,
                                  self._supinfo)
 
     def test_04_(self):
-        """ Chequear tipos de campo currency -------------------------------004
+        """ currency es un string -------------------------------------------04
         """
-        line = [
-            '123456789',
-            'nombre-producto',
-            'Descripción del producto',
-            '7750082001169,7750082001169',
-            '100a0.52',
-            '501',
-            '200.50',
-            '125.85',
-            '601.AA.3157.jpg',
-            '60',
-            '21',
-            '001',
-            '2018-25-01 13:10:55']
-
+        line = self.line
+        line[MAP_STANDARD_PRICE] = 'HHH'  # debe ser currency y es string
         with self.assertRaises(Exception):
             prod = ProductMapper(line, self._data_path, self._vendor,
                                  self._supinfo)
 
     def test_05_(self):
-        """ Chequear tipos de campo -----------------------------------------05
+        """ float es un string ----------------------------------------------05
         """
-        line = [
-            '123456789',
-            'nombre-producto',
-            'Descripción del producto',
-            '7750082001169,7750082001169',
-            '1000.52',
-            '500',
-            '200q',
-            '125.85',
-            '601.AA.3157.jpg',
-            '60',
-            '21',
-            '001',
-            '2018-25-01 13:10:55']
-
+        line = self.line
+        line[MAP_WEIGHT] = 'HHH'  # debe ser numero y es string
         with self.assertRaises(Exception):
             prod = ProductMapper(line, self._data_path, self._vendor,
                                  self._supinfo)
@@ -175,10 +163,6 @@ class TestBusiness(TransactionCase):
     def test_06_update(self):
         """ Chequear que NO replique registros viejos------------------------06
         """
-        # verificar create
-        manager_obj = self.env['product_autoload.manager']
-        prod_obj = self.env['product.template']
-
         # fecha de los registros 2018-01-26 16:13:21
         # con esta fecha no deberia replicar nada
         self.env['ir.config_parameter'].set_param(
@@ -186,19 +170,15 @@ class TestBusiness(TransactionCase):
         self.env['ir.config_parameter'].set_param(
             'import_only_new', True)
 
-        manager_obj.run()
-        prod = prod_obj.search([('default_code', '=', '102.AF')])
+        self.manager_obj.run()
+        prod = self.prod_obj.search([('default_code', '=', '102.AF')])
         self.assertFalse(prod)
-        prod = prod_obj.search([('default_code', '=', '106.32')])
+        prod = self.prod_obj.search([('default_code', '=', '106.32')])
         self.assertFalse(prod)
 
     def test_07_update_product(self):
         """ Chequear que SI replique registros nuevos------------------------07
         """
-        # verificar create
-        manager_obj = self.env['product_autoload.manager']
-        prod_obj = self.env['product.template']
-
         # fecha de los registros 2018-01-26 16:13:21
         # con esta fecha si deberia replicar
         self.env['ir.config_parameter'].set_param(
@@ -206,20 +186,17 @@ class TestBusiness(TransactionCase):
         self.env['ir.config_parameter'].set_param(
             'import_only_new', True)
 
-        manager_obj.run()
-        prod = prod_obj.search([('default_code', '=', '102.AF')])
+        self.manager_obj.run()
+        prod = self.prod_obj.search([('default_code', '=', '102.AF')])
         self.assertTrue(prod)
-        prod = prod_obj.search([('default_code', '=', '106.32')])
+        self.assertTrue(prod.invalidate_category)
+        prod = self.prod_obj.search([('default_code', '=', '106.32')])
         self.assertTrue(prod)
         self.assertTrue(prod.invalidate_category)
 
     def test_08_update_product(self):
         """ Chequear que SI replique si fuerzo la replicacion----------------08
         """
-        # verificar create
-        manager_obj = self.env['product_autoload.manager']
-        prod_obj = self.env['product.template']
-
         # fecha de los registros 2018-01-26 16:13:21
         # con esta fecha no deberia replicar nada
         self.env['ir.config_parameter'].set_param(
@@ -228,56 +205,53 @@ class TestBusiness(TransactionCase):
         self.env['ir.config_parameter'].set_param(
             'import_only_new', False)
 
-        manager_obj.run()
-        prod = prod_obj.search([('default_code', '=', '102.AF')])
+        self.manager_obj.run()
+        prod = self.prod_obj.search([('default_code', '=', '102.AF')])
         self.assertTrue(prod)
-        prod = prod_obj.search([('default_code', '=', '106.32')])
+        prod = self.prod_obj.search([('default_code', '=', '106.32')])
         self.assertTrue(prod)
 
-    def test_09_barcodes(self):
-        """ Testear que el unlink borra todo --------------------------------09
+    def test_09_categories(self):
+        """ Actualizacion de categorias y precios de lista ------------------09
         """
-        # verificar create
-        manager_obj = self.env['product_autoload.manager']
         prod_obj = self.env['product.template']
-        manager_obj.run()
 
-        barcode_obj = self.env['product.barcode']
-        for bc in barcode_obj.search([('product_id.name', '=', '102.7811')]):
-            self.assertTrue(bc.barcode in ['5449000000996', '299999134500'])
+        self.manager_obj.run()
+        prod = prod_obj.search([('default_code', '=', '102.B.12')])
+        self.assertEqual(prod.bulonfer_cost, 2.2372)
+        prod = prod_obj.search([('default_code', '=', '106.32')])
+        self.assertEqual(prod.bulonfer_cost, 15.0620)
 
-    def test_010_categories(self):
-        """ Testear actualizacion de categorias------------------------------10
-        """
-        # verificar create
-        manager_obj = self.env['product_autoload.manager']
-        manager_obj.run()
-        manager_obj.update_categories()
-        # verificar que se crean bien las categorias
+        self.manager_obj.update_categories()
 
+        # verificar creacion de categorias
         categ_obj = self.env['product.category']
         categs = categ_obj.search([('name', '=', 'Ferretería'),
                                    ('parent_id', '=', False)])
         self.assertEqual(len(categs), 1)
 
-    def test_020_cambia_margen(self):
-        """ Testear cambio de margen de ganancia-----------------------------20
+        # verificar precios de lista
+        prod = prod_obj.search([('default_code', '=', '102.B.12')])
+        self.assertAlmostEqual(prod.list_price, 2.2372 * 1.5, places=2)
+        prod = prod_obj.search([('default_code', '=', '106.32')])
+        self.assertAlmostEqual(prod.list_price, 15.0620 * 1.5, places=2)
+
+    def test_10_cambia_margen(self):
+        """ Testear cambio de margen de ganancia-----------------------------10
         """
-        prod_obj = self.env['product.template']
 
-        manager_obj = self.env['product_autoload.manager']
-        manager_obj.run()
-        manager_obj.update_categories()
+        self.manager_obj.run()
+        self.manager_obj.update_categories()
 
-        prod = prod_obj.search([('default_code', '=', '106.24')])
-        self.assertAlmostEqual(prod.standard_price, 150.62)
-        self.assertAlmostEqual(prod.standard_price * 1.5, prod.list_price,
+        prod = self.prod_obj.search([('default_code', '=', '106.24')])
+        self.assertAlmostEqual(prod.bulonfer_cost, 150.62)
+        self.assertAlmostEqual(prod.bulonfer_cost * 1.5, prod.list_price,
                                places=2)
 
-        # import wdb;wdb.set_trace()
-        manager_obj.run(item='item_changed.csv')
-        manager_obj.update_categories()
+        self.manager_obj.run(item='item_changed.csv')
+        self.manager_obj.update_categories()
 
-        prod = prod_obj.search([('default_code', '=', '106.24')])
-        self.assertAlmostEqual(prod.standard_price * 1.6, prod.list_price,
+        prod = self.prod_obj.search([('default_code', '=', '106.24')])
+        self.assertAlmostEqual(prod.bulonfer_cost * 1.6, prod.list_price,
                                places=2)
+

--- a/product_autoload/views/product_view.xml
+++ b/product_autoload/views/product_view.xml
@@ -3,20 +3,73 @@
     <data>
         <!-- agregar difference - diferencia entre factura y sistema -->
 
-        <record id="product_template_tree_view" model="ir.ui.view">
-            <field name="name">AUTOLOAD: add difference</field>
+        <record id="product_template_tree_view1" model="ir.ui.view">
+            <field name="name">AUTOLOAD: add cost fields</field>
             <field name="model">product.template</field>
             <field name="inherit_id" ref="product.product_template_tree_view"/>
             <field name="arch" type="xml">
                 <field name="name" position="after">
-                    <field name="difference" string="Dif%"
-                           groups="iomaq_default.group_administrative_users,base.group_erp_manager"/>
-                    <field name="margin" string="Margen%"
-                           groups="iomaq_default.group_administrative_users,base.group_erp_manager"/>
-                    <field name="system_cost" string="Costo Factura"
-                           groups="iomaq_default.group_administrative_users,base.group_erp_manager"/>
+                    <field name="difference" string="Dif%"/>
+                    <field name="margin" string="Margin%"/>
+                    <field name="system_cost" string="Invoice Cost"/>
+                    <field name="bulonfer_cost" string="Today Cost"/>
+                    <field name="oldest_cost"/>
+                </field>
+                <field name="standard_price" position="attributes">
+                    <attribute name="invisible">1</attribute>
                 </field>
             </field>
         </record>
+
+        <record id="product_template_tree_view2" model="ir.ui.view">
+            <field name="name">AUTOLOAD: hide cost fields</field>
+            <field name="model">product.template</field>
+            <field name="groups_id"
+                   eval="[(6, 0, [ref('price_security.group_restrict_prices')])]"/>
+            <field name="inherit_id" ref="product_template_tree_view1"/>
+            <field name="arch" type="xml">
+                <field name="difference" position="attributes">
+                    <attribute name="invisible">1</attribute>
+                </field>
+                <field name="margin" position="attributes">
+                    <attribute name="invisible">1</attribute>
+                </field>
+                <field name="system_cost" position="attributes">
+                    <attribute name="invisible">1</attribute>
+                </field>
+                <field name="bulonfer_cost" position="attributes">
+                    <attribute name="invisible">1</attribute>
+                </field>
+                <field name="oldest_cost" position="attributes">
+                    <attribute name="invisible">1</attribute>
+                </field>
+            </field>
+        </record>
+
+        <record id="product_template_tree_view3" model="ir.ui.view">
+            <field name="name">AUTOLOAD: show cost fields</field>
+            <field name="model">product.template</field>
+            <field name="groups_id"
+                   eval="[(6, 0, [ref('price_security.group_only_view')])]"/>
+            <field name="inherit_id" ref="product_template_tree_view1"/>
+            <field name="arch" type="xml">
+                <field name="difference" position="attributes">
+                    <attribute name="invisible">0</attribute>
+                </field>
+                <field name="margin" position="attributes">
+                    <attribute name="invisible">0</attribute>
+                </field>
+                <field name="system_cost" position="attributes">
+                    <attribute name="invisible">0</attribute>
+                </field>
+                <field name="bulonfer_cost" position="attributes">
+                    <attribute name="invisible">0</attribute>
+                </field>
+                <field name="oldest_cost" position="attributes">
+                    <attribute name="invisible">0</attribute>
+                </field>
+            </field>
+        </record>
+
     </data>
 </openerp>


### PR DESCRIPTION
- Al importar, costo ya no se carga en standard_price se carga en bulonfer_cost
- La carga de datos en supplierinfo ya no se hace en ProductMapper se mueve a product.template  set_cost() y se salva la historia de cambios de precio
- Se agrega una variable oldest_cost solo para reducir la cantidad de decimales mostrados en la list view
- Ahora muestra los costos o no teniendo en cuenta como se configura price_security en el perfil del usuario, Depende de price_security