### PR TITLE
9.0.widgets#123 modulo due_payments_argentina_fix

### DIFF
--- a/due_payments_argentina_fix/README.rst
+++ b/due_payments_argentina_fix/README.rst
@@ -17,6 +17,15 @@ pagos pendientes que esta en la ficha del cliente.
 En la columna Numero de referencia pone el numero de factura AFIP en lugar de
 la referncia interna de odoo que obviamente el cliente no conoce.
 
+Correccion de widgets de conciliacion
+=====================================
+
+En los widgets de conciliacion que aparecen en las facturas se muestran los
+documentos segun los nombres tradicionales de odoo, este modulo cambia esos
+nombres por los de la localizacion argentina por ejemplo FA-A 0001-00000248
+o RE-X 0001-00000548 para un mejor entendimiento de se esta conciliando.
+
+
 Installation
 ============
 

--- a/due_payments_argentina_fix/__openerp__.py
+++ b/due_payments_argentina_fix/__openerp__.py
@@ -20,7 +20,7 @@
 ##############################################################################
 {
     'name': 'Correccion reporte de pagos pendientes',
-    'version': '9.0.0.0.0',
+    'version': '9.0.1.0.0',
     'category': 'Tools',
     'summary': "Corrije el reporte poniendo el numero de factura AFIP",
     'author': "jeo Software",

--- a/due_payments_argentina_fix/models/__init__.py
+++ b/due_payments_argentina_fix/models/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
 # For copyright and license notices, see __manifest__.py file in module root
 
-from . import report
-from . import models
+from . import account_invoice

--- a/due_payments_argentina_fix/models/account_invoice.py
+++ b/due_payments_argentina_fix/models/account_invoice.py
@@ -2,17 +2,8 @@
 # For copyright and license notices, see __manifest__.py file in module root
 
 import json
-from lxml import etree
-from datetime import datetime
-from dateutil.relativedelta import relativedelta
-
 from openerp import api, fields, models, _
 from openerp.tools import float_is_zero, float_compare
-from openerp.tools.misc import formatLang
-
-from openerp.exceptions import UserError, RedirectWarning, ValidationError
-
-import openerp.addons.decimal_precision as dp
 import logging
 
 _logger = logging.getLogger(__name__)

--- a/due_payments_argentina_fix/models/account_invoice.py
+++ b/due_payments_argentina_fix/models/account_invoice.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+# For copyright and license notices, see __manifest__.py file in module root
+
+import json
+from lxml import etree
+from datetime import datetime
+from dateutil.relativedelta import relativedelta
+
+from openerp import api, fields, models, _
+from openerp.tools import float_is_zero, float_compare
+from openerp.tools.misc import formatLang
+
+from openerp.exceptions import UserError, RedirectWarning, ValidationError
+
+import openerp.addons.decimal_precision as dp
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+class AccountInvoice(models.Model):
+    _inherit = "account.invoice"
+
+    @api.one
+    def _get_outstanding_info_JSON(self):
+        self.outstanding_credits_debits_widget = json.dumps(False)
+        if self.state == 'open':
+            domain = [('account_id', '=', self.account_id.id), ('partner_id', '=', self.env['res.partner']._find_accounting_partner(self.partner_id).id), ('reconciled', '=', False), ('amount_residual', '!=', 0.0)]
+            if self.type in ('out_invoice', 'in_refund'):
+                domain.extend([('credit', '>', 0), ('debit', '=', 0)])
+                type_payment = _('Outstanding credits')
+            else:
+                domain.extend([('credit', '=', 0), ('debit', '>', 0)])
+                type_payment = _('Outstanding debits')
+            info = {'title': '', 'outstanding': True, 'content': [], 'invoice_id': self.id}
+            lines = self.env['account.move.line'].search(domain)
+            currency_id = self.currency_id
+            if len(lines) != 0:
+                for line in lines:
+                    # get the outstanding residual value in invoice currency
+                    if line.currency_id and line.currency_id == self.currency_id:
+                        amount_to_show = abs(line.amount_residual_currency)
+                    else:
+                        amount_to_show = line.company_id.currency_id.with_context(date=line.date).compute(abs(line.amount_residual), self.currency_id)
+                    if float_is_zero(amount_to_show, precision_rounding=self.currency_id.rounding):
+                        continue
+                    info['content'].append({
+                        'journal_name': line.ref or line.move_id.display_name,
+                        'amount': amount_to_show,
+                        'currency': currency_id.symbol,
+                        'id': line.id,
+                        'position': currency_id.position,
+                        'digits': [69, self.currency_id.decimal_places],
+                    })
+                info['title'] = type_payment
+                self.outstanding_credits_debits_widget = json.dumps(info)
+                self.has_outstanding = True
+
+    @api.one
+    @api.depends('payment_move_line_ids.amount_residual')
+    def _get_payment_info_JSON(self):
+        self.payments_widget = json.dumps(False)
+        if self.payment_move_line_ids:
+            info = {'title': _('Less Payment'), 'outstanding': False, 'content': []}
+            currency_id = self.currency_id
+            for payment in self.payment_move_line_ids:
+                payment_currency_id = False
+                if self.type in ('out_invoice', 'in_refund'):
+                    amount = sum([p.amount for p in payment.matched_debit_ids if p.debit_move_id in self.move_id.line_ids])
+                    amount_currency = sum([p.amount_currency for p in payment.matched_debit_ids if p.debit_move_id in self.move_id.line_ids])
+                    if payment.matched_debit_ids:
+                        payment_currency_id = all([p.currency_id == payment.matched_debit_ids[0].currency_id for p in payment.matched_debit_ids]) and payment.matched_debit_ids[0].currency_id or False
+                elif self.type in ('in_invoice', 'out_refund'):
+                    amount = sum([p.amount for p in payment.matched_credit_ids if p.credit_move_id in self.move_id.line_ids])
+                    amount_currency = sum([p.amount_currency for p in payment.matched_credit_ids if p.credit_move_id in self.move_id.line_ids])
+                    if payment.matched_credit_ids:
+                        payment_currency_id = all([p.currency_id == payment.matched_credit_ids[0].currency_id for p in payment.matched_credit_ids]) and payment.matched_credit_ids[0].currency_id or False
+                # get the payment value in invoice currency
+                if payment_currency_id and payment_currency_id == self.currency_id:
+                    amount_to_show = amount_currency
+                else:
+                    amount_to_show = payment.company_id.currency_id.with_context(date=payment.date).compute(amount, self.currency_id)
+                if float_is_zero(amount_to_show, precision_rounding=self.currency_id.rounding):
+                    continue
+                payment_ref = payment.move_id.display_name
+                if payment.move_id.ref:
+                    payment_ref += ' (' + payment.move_id.ref + ')'
+                info['content'].append({
+                    'name': payment.name,
+                    'journal_name': payment.journal_id.name,
+                    'amount': amount_to_show,
+                    'currency': currency_id.symbol,
+                    'digits': [69, currency_id.decimal_places],
+                    'position': currency_id.position,
+                    'date': payment.date,
+                    'payment_id': payment.id,
+                    'move_id': payment.move_id.id,
+                    'ref': payment_ref,
+                })
+            self.payments_widget = json.dumps(info)


### PR DESCRIPTION
En los widgets de conciliacion que aparecen en las facturas se muestran los
documentos segun los nombres tradicionales de odoo, este modulo cambia esos
nombres por los de la localizacion argentina por ejemplo FA-A 0001-00000248
o RE-X 0001-00000548 para un mejor entendimiento de se esta conciliando.
